### PR TITLE
Intersection search

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"strings"
 
 	"github.com/cgxeiji/scholar/scholar"
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ var editCmd = &cobra.Command{
 Edit an entry's metadata using the default's text editor.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if entry := queryEntry(strings.Join(args, " ")); entry != nil {
+		if entry := queryEntry(args); entry != nil {
 			if attachFlag != "" {
 				attach(entry, attachFlag)
 				return

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/cgxeiji/scholar/scholar"
 	"github.com/spf13/cobra"
@@ -67,7 +66,7 @@ func init() {
 
 func export(args []string) {
 	if len(args) != 0 {
-		if found := guiSearch(strings.Join(args, " "), entryList(), searcher); len(found) != 0 {
+		if found := guiSearch(args, entryList(), searcher); len(found) != 0 {
 			for _, e := range found {
 				fmt.Println(e.Export(exportFormat))
 				if exportFormat != "ris" {

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -32,7 +31,7 @@ Fetch the file path attached to an entry and print the result to stdout.
 If no file is attached, it exists with 1.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if entry := queryEntry(strings.Join(args, " ")); entry != nil {
+		if entry := queryEntry(args); entry != nil {
 			if entry.File != "" {
 				fmt.Println(filepath.Join(libraryPath(), entry.GetKey(), entry.File))
 			} else if url, ok := entry.Optional["url"]; ok && url != "" {

--- a/cmd/general.go
+++ b/cmd/general.go
@@ -229,7 +229,7 @@ func checkDirKey(path, dir string, e *scholar.Entry) {
 		filepath.Join(path, e.GetKey()))
 }
 
-func queryEntry(search string) *scholar.Entry {
+func queryEntry(search []string) *scholar.Entry {
 	var entry *scholar.Entry
 
 	if viper.GetBool("GENERAL.interactive") != viper.GetBool("interactive") {

--- a/cmd/gui.go
+++ b/cmd/gui.go
@@ -141,8 +141,8 @@ func guiQuery(entries []*scholar.Entry, search []string) *scholar.Entry {
 			}
 			v.Editable = true
 			v.Title = "SEARCH BAR"
-			search_string := strings.Join(search, " ")
-			fmt.Fprint(v, search_string)
+			searchString := strings.Join(search, " ")
+			fmt.Fprint(v, searchString)
 
 			// Check if the initial search is a unique result
 			found := guiSearch(search, entries, searcher)
@@ -156,7 +156,7 @@ func guiQuery(entries []*scholar.Entry, search []string) *scholar.Entry {
 				showInfoCh <- found[0]
 			}
 
-			v.SetCursor(len(search_string), 0)
+			v.SetCursor(len(searchString), 0)
 			resetCursorCh <- true
 
 			v.Editor = gocui.EditorFunc(func(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -55,7 +55,7 @@ TODO: if there is no file attached, the entry's metadata file is opened.
 --------------------------------------------------------------------------------
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if entry := queryEntry(strings.Join(args, " ")); entry != nil {
+		if entry := queryEntry(args); entry != nil {
 			if entry.File != "" {
 				open(filepath.Join(libraryPath(), entry.GetKey(), entry.File))
 			} else if url, ok := entry.Optional["url"]; ok && url != "" {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -40,7 +39,7 @@ Remove an entry from the library.  If interactive mode is disabled, the entry
 will be removed without confirmation.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if entry := queryEntry(strings.Join(args, " ")); entry != nil {
+		if entry := queryEntry(args); entry != nil {
 			path := filepath.Join(libraryPath(), entry.GetKey())
 			if viper.GetBool("GENERAL.interactive") != viper.GetBool("interactive") {
 				if askYesNo(fmt.Sprintf("Do you want to remove %s?", path)) {


### PR DESCRIPTION
Existing search behavior (used in fetch, open, edit etc.) is to accept multiple search terms from the CLI, but join them together before passing to the search functions, meaning that search is always for a verbatim string.

These changes preserve that behavior for quoted multiword search terms. However for unquoted search terms, we now pass them through as an array, search on each separately, and return the intersection of entries matching each term.

Let me know if this is to your liking!